### PR TITLE
Progress bar V1

### DIFF
--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -20,17 +20,30 @@ export default ProgressBarExercise;
 
 // ----------------------------------------------------------------------------------
 
+const strings = {
+  LOADING: "LOADING",
+  START_REQUEST: "START REQUEST",
+  FINISH_REQUEST: "FINISH REQUEST",
+};
+
 const Solution = () => {
-  const { status, startRequest, finishRequest } = useSimulateRequest();
+  const { isLoading, isFinishing, startRequest, finishRequest } =
+    useSimulateRequest();
+
   return (
     <div>
-      {/* Note -- this separation of concerns isn't ideal since the component needs to know 
-      the exact strings in hook. See if there is a cleaner way to accomplish that. */}
-      <ProgressBar status={status} />
-      {/* TODO, add state for loading button text */}
-      <Button onClick={startRequest}>START REQUEST</Button>
-      {/* Note - ideally these strings would be kept elsewhere for easier translations */}
-      <Button onClick={finishRequest}>FINISH REQUEST</Button>
+      <ProgressBar isLoading={isLoading} isFinishing={isFinishing} />
+
+      {/* Note - Would normally use a layout component or tailwind here */}
+      <div style={{ display: "flex", justifyContent: "center", gap: "20px" }}>
+        <Button onClick={startRequest}>
+          {isLoading ? strings.LOADING : strings.START_REQUEST}
+        </Button>
+
+        <Button onClick={finishRequest} color="danger">
+          {strings.FINISH_REQUEST}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,5 +1,8 @@
 import React from "react";
 import Exercise from "../exercise/Exercise";
+import Button from "./components/button/Button";
+import ProgressBar from "./components/progress_bar/ProgressBar";
+import useSimulateRequest from "./hooks/useSimulateNetworkRequest";
 
 const ProgressBarExercise = () => {
   return (
@@ -18,5 +21,16 @@ export default ProgressBarExercise;
 // ----------------------------------------------------------------------------------
 
 const Solution = () => {
-  return <div>Add solution here</div>;
+  const { status, startRequest, finishRequest } = useSimulateRequest();
+  return (
+    <div>
+      {/* Note -- this separation of concerns isn't ideal since the component needs to know 
+      the exact strings in hook. See if there is a cleaner way to accomplish that. */}
+      <ProgressBar status={status} />
+      {/* TODO, add state for loading button text */}
+      <Button onClick={startRequest}>START REQUEST</Button>
+      {/* Note - ideally these strings would be kept elsewhere for easier translations */}
+      <Button onClick={finishRequest}>FINISH REQUEST</Button>
+    </div>
+  );
 };

--- a/src/progress_bar_exercise/components/button/Button.js
+++ b/src/progress_bar_exercise/components/button/Button.js
@@ -1,10 +1,9 @@
 import React from "react";
 import "./Button.scss";
 
-export default function Button({ children, onClick }) {
+export default function Button({ children, onClick, color }) {
   return (
-    // TODO - handle color change request
-    <button className="button" onClick={onClick}>
+    <button className={`button ${color}`} onClick={onClick}>
       {children}
     </button>
   );

--- a/src/progress_bar_exercise/components/button/Button.js
+++ b/src/progress_bar_exercise/components/button/Button.js
@@ -1,0 +1,11 @@
+import React from "react";
+import "./Button.scss";
+
+export default function Button({ children, onClick }) {
+  return (
+    // TODO - handle color change request
+    <button className="button" onClick={onClick}>
+      {children}
+    </button>
+  );
+}

--- a/src/progress_bar_exercise/components/button/Button.scss
+++ b/src/progress_bar_exercise/components/button/Button.scss
@@ -15,3 +15,8 @@
 .button:active {
   border-width: 3px;
 }
+
+.button.danger {
+  color: $red;
+  border-color: $red;
+}

--- a/src/progress_bar_exercise/components/button/Button.scss
+++ b/src/progress_bar_exercise/components/button/Button.scss
@@ -1,0 +1,17 @@
+@import "../../../shared_styles/colors.scss";
+
+.button {
+  border: 1px $green solid;
+  padding: 20px 40px;
+  border-radius: 40px;
+
+  color: $green;
+}
+
+.button:hover {
+  border-width: 2px;
+}
+
+.button:active {
+  border-width: 3px;
+}

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
@@ -1,0 +1,10 @@
+import React from "react";
+import "./ProgressBar.scss";
+
+export default function ProgressBar({ status }) {
+  return (
+    <div className="progress">
+      <div className={`progress-bar progress-bar--${status}`}></div>
+    </div>
+  );
+}

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
@@ -1,7 +1,11 @@
 import React from "react";
 import "./ProgressBar.scss";
 
-export default function ProgressBar({ status }) {
+export default function ProgressBar({ isLoading, isFinishing }) {
+  // Note - would normally use classnames lib, but intentionally leaving that out for the interview
+  let status = isLoading ? "loading" : "";
+  status = isFinishing ? "finishing" : status;
+
   return (
     <div className="progress">
       <div className={`progress-bar progress-bar--${status}`}></div>

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.scss
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.scss
@@ -1,0 +1,26 @@
+@import "../../../shared_styles/colors.scss";
+
+.progress {
+  height: 6px;
+  border-radius: 40px;
+}
+
+.progress-bar {
+  height: 5px;
+  width: 1px;
+  opacity: 0;
+  border-radius: inherit;
+  background: linear-gradient(to right, $sunrise, $red);
+  transition: width 15s;
+}
+
+.progress-bar--loading {
+  width: 90%;
+  opacity: 1;
+}
+
+.progress-bar--finishing {
+  transition: width 1s, opacity 2s 4s;
+  opacity: 0;
+  width: 100%;
+}

--- a/src/progress_bar_exercise/hooks/useSimulateNetworkRequest.js
+++ b/src/progress_bar_exercise/hooks/useSimulateNetworkRequest.js
@@ -1,15 +1,19 @@
 import { useState } from "react";
 
+const STATUS = {
+  IDLE: "IDLE",
+  LOADING: "LOADING",
+  FINISHING: "FINISHING",
+};
+
 export default function useSimulateRequest() {
-  const [status, setStatus] = useState("idle");
+  const [status, setStatus] = useState(STATUS.IDLE);
 
-  function startRequest() {
-    setStatus("loading");
-  }
+  const startRequest = () => setStatus(STATUS.LOADING);
+  const finishRequest = () => setStatus(STATUS.FINISHING);
 
-  function finishRequest() {
-    setStatus("finishing");
-  }
+  const isLoading = status === STATUS.LOADING;
+  const isFinishing = status === STATUS.FINISHING;
 
-  return { status, startRequest, finishRequest };
+  return { isLoading, isFinishing, startRequest, finishRequest };
 }

--- a/src/progress_bar_exercise/hooks/useSimulateNetworkRequest.js
+++ b/src/progress_bar_exercise/hooks/useSimulateNetworkRequest.js
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export default function useSimulateRequest() {
+  const [status, setStatus] = useState("idle");
+
+  function startRequest() {
+    setStatus("loading");
+  }
+
+  function finishRequest() {
+    setStatus("finishing");
+  }
+
+  return { status, startRequest, finishRequest };
+}


### PR DESCRIPTION
### Overview

[Link to design spec](https://github.com/SpiffInc/spiff_react_exercises/issues/1)
[Link to video recording](https://www.dropbox.com/s/4glf2omwbmmvhw6/progress-bar-v1.mov?dl=0)

Progress Bar version 1 is a horizontal progress bar that emulates a network request. The progress bar doesn't display or keep track of the actual progress. Instead, it loads incrementally over 15 seconds to 90%, and then whenever it's completed, it takes 1 more second to load to 100%. 

### Approach
My approach to V1 was to complete the task as clean and simple as possible. Even though I was aware that V2 might need significant overhauling, it wasn't clear to me if V2 was a final design or not, so I made each version standalone.

In V1, the only major decision was whether to use css or js for the animation effect. Whenever possible, I try to lean on CSS to handle the animation, since it's usually cleaner code. However, it's unclear if there is any performance benefit from doing so. 

### Acceptance Criteria
## Styling
- [x] the bar should be 6px tall and use a gradient that starts orange and ends red
- [x] buttons should match the style below. On hover, button borders should increase to 2px width. On click, the border should increase to 3px.

## Emulating the request
- [x] add a green Start Request button to the canvas area that initiates the fake request. This button should change from Start Request to Loading... while the progress bar is active
- [x] add a red Finish Request button to the canvas area that completes the fake request.

Animation
- [x] the bar should animate progress from 0% to 90% over 15 seconds
- [x] if the request doesn't finish within 15 seconds, the bar should hang at 90%
- [x] the bar should animate to 100% (in 1 second) when the request finishes regardless of it's current position. It should then disappear 3 seconds later. Bonus: fade the bar away

### Known callouts/concerns
- currently the progress bar fades away when completed, but it isn't removed from the DOM or reset. This behavior wasn't called out, but I believe it'd be worth baking this in. 
- some minor improvements could be made by using the classnames lib / tailwind / css in js
- In this PR, some conversational notes are left in the code and should be pulled out into PR Notes. In the V2 PR, I've already made that change. 