### PR TITLE
Progress Bar V2

### DIFF
--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Exercise from "../exercise/Exercise";
 import Button from "./components/button/Button";
 import ProgressBar from "./components/progress_bar/ProgressBar";
@@ -26,27 +26,39 @@ const strings = {
   FINISH_REQUEST: "FINISH REQUEST",
 };
 
+const divContainerStyle = {
+  display: "flex",
+  justifyContent: "center",
+  gap: "20px",
+  padding: "20px",
+  margin: "20px",
+};
+
 const Solution = () => {
   const { isLoading, isFinishing, startRequest, finishRequest } =
     useSimulateRequest();
+  const [showProgressBarV2, setShowProgressBarV2] = useState(false);
 
   return (
     <div>
       <ProgressBar
         isLoading={isLoading}
         isFinishing={isFinishing}
-        // TODO - built 90 in as default since other parts of the code expect it
         breakpoints={[20, 40, 60, 90]}
+        showV2={showProgressBarV2}
       />
 
-      {/* Note - Would normally use a layout component or tailwind here */}
-      <div style={{ display: "flex", justifyContent: "center", gap: "20px" }}>
+      <div style={divContainerStyle}>
         <Button onClick={startRequest}>
           {isLoading ? strings.LOADING : strings.START_REQUEST}
         </Button>
 
         <Button onClick={finishRequest} color="danger">
           {strings.FINISH_REQUEST}
+        </Button>
+
+        <Button onClick={() => setShowProgressBarV2(!showProgressBarV2)}>
+          {showProgressBarV2 ? "SHOW V1" : "SHOW V2"}
         </Button>
       </div>
     </div>

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -20,17 +20,30 @@ export default ProgressBarExercise;
 
 // ----------------------------------------------------------------------------------
 
+const strings = {
+  LOADING: "LOADING",
+  START_REQUEST: "START REQUEST",
+  FINISH_REQUEST: "FINISH REQUEST",
+};
+
 const Solution = () => {
-  const { status, startRequest, finishRequest } = useSimulateRequest();
+  const { isLoading, isFinishing, startRequest, finishRequest } =
+    useSimulateRequest();
+
   return (
     <div>
-      {/* Note -- this separation of concerns isn't ideal since the component needs to know 
-      the exact strings in hook. See if there is a cleaner way to accomplish that. */}
-      <ProgressBar status={status} />
-      {/* TODO, add state for loading button text */}
-      <Button onClick={startRequest}>START REQUEST</Button>
-      {/* Note - ideally these strings would be kept elsewhere for easier translations */}
-      <Button onClick={finishRequest}>FINISH REQUEST</Button>
+      <ProgressBar isLoading={isLoading} isFinishing={isFinishing} />
+
+      {/* Note - Would normally use a layout component or tailwind here */}
+      <div style={{ display: "flex", justifyContent: "center", gap: "20px" }}>
+        <Button onClick={startRequest}>
+          {isLoading ? strings.LOADING : strings.START_REQUEST}
+        </Button>
+
+        <Button onClick={finishRequest} color="danger">
+          {strings.FINISH_REQUEST}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -32,7 +32,12 @@ const Solution = () => {
 
   return (
     <div>
-      <ProgressBar isLoading={isLoading} isFinishing={isFinishing} />
+      <ProgressBar
+        isLoading={isLoading}
+        isFinishing={isFinishing}
+        // TODO - built 90 in as default since other parts of the code expect it
+        breakpoints={[20, 40, 60, 90]}
+      />
 
       {/* Note - Would normally use a layout component or tailwind here */}
       <div style={{ display: "flex", justifyContent: "center", gap: "20px" }}>

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,5 +1,8 @@
 import React from "react";
 import Exercise from "../exercise/Exercise";
+import Button from "./components/button/Button";
+import ProgressBar from "./components/progress_bar/ProgressBar";
+import useSimulateRequest from "./hooks/useSimulateNetworkRequest";
 
 const ProgressBarExercise = () => {
   return (
@@ -18,5 +21,16 @@ export default ProgressBarExercise;
 // ----------------------------------------------------------------------------------
 
 const Solution = () => {
-  return <div>Add solution here</div>;
+  const { status, startRequest, finishRequest } = useSimulateRequest();
+  return (
+    <div>
+      {/* Note -- this separation of concerns isn't ideal since the component needs to know 
+      the exact strings in hook. See if there is a cleaner way to accomplish that. */}
+      <ProgressBar status={status} />
+      {/* TODO, add state for loading button text */}
+      <Button onClick={startRequest}>START REQUEST</Button>
+      {/* Note - ideally these strings would be kept elsewhere for easier translations */}
+      <Button onClick={finishRequest}>FINISH REQUEST</Button>
+    </div>
+  );
 };

--- a/src/progress_bar_exercise/components/button/Button.js
+++ b/src/progress_bar_exercise/components/button/Button.js
@@ -1,10 +1,9 @@
 import React from "react";
 import "./Button.scss";
 
-export default function Button({ children, onClick }) {
+export default function Button({ children, onClick, color }) {
   return (
-    // TODO - handle color change request
-    <button className="button" onClick={onClick}>
+    <button className={`button ${color}`} onClick={onClick}>
       {children}
     </button>
   );

--- a/src/progress_bar_exercise/components/button/Button.js
+++ b/src/progress_bar_exercise/components/button/Button.js
@@ -1,0 +1,11 @@
+import React from "react";
+import "./Button.scss";
+
+export default function Button({ children, onClick }) {
+  return (
+    // TODO - handle color change request
+    <button className="button" onClick={onClick}>
+      {children}
+    </button>
+  );
+}

--- a/src/progress_bar_exercise/components/button/Button.scss
+++ b/src/progress_bar_exercise/components/button/Button.scss
@@ -4,6 +4,7 @@
   border: 1px $green solid;
   padding: 20px 40px;
   border-radius: 40px;
+  height: 60px;
 
   color: $green;
 }

--- a/src/progress_bar_exercise/components/button/Button.scss
+++ b/src/progress_bar_exercise/components/button/Button.scss
@@ -15,3 +15,8 @@
 .button:active {
   border-width: 3px;
 }
+
+.button.danger {
+  color: $red;
+  border-color: $red;
+}

--- a/src/progress_bar_exercise/components/button/Button.scss
+++ b/src/progress_bar_exercise/components/button/Button.scss
@@ -1,0 +1,17 @@
+@import "../../../shared_styles/colors.scss";
+
+.button {
+  border: 1px $green solid;
+  padding: 20px 40px;
+  border-radius: 40px;
+
+  color: $green;
+}
+
+.button:hover {
+  border-width: 2px;
+}
+
+.button:active {
+  border-width: 3px;
+}

--- a/src/progress_bar_exercise/components/hider/Hider.js
+++ b/src/progress_bar_exercise/components/hider/Hider.js
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from "react";
+
+/**
+ * Hider Component removes children components from the
+ * DOM after some given time
+ */
+export default function Hider({ shouldHide, delayTime, children }) {
+  const [show, setShow] = useState(true);
+  useEffect(() => {
+    if (shouldHide) {
+      if (!delayTime) {
+        setShow(false);
+      }
+      setTimeout(() => {
+        setShow(false);
+      }, delayTime);
+    }
+  }, [delayTime, shouldHide]);
+  return <>{show && children}</>;
+}

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
@@ -2,20 +2,21 @@ import React from "react";
 import "./ProgressBar.scss";
 import useVariableProgress from "./useVariableProgress";
 
-// ProgressBar simulates the current progress.
-export default function ProgressBar({ isLoading, isFinishing, breakpoints }) {
+export default function ProgressBar({
+  isLoading,
+  isFinishing,
+  breakpoints,
+  showV2,
+}) {
   const { width, duration } = useVariableProgress(isLoading, breakpoints);
 
-  // Styling
-  // Note - would normally use classnames lib, but intentionally leaving that out for the interview
-  let status = isLoading ? "loading" : "";
-  status = isFinishing ? "finishing" : status;
+  const status = isLoading ? "loading" : isFinishing ? "finishing" : "";
 
   return (
     <div className="progress">
       <div
         style={
-          isLoading
+          isLoading && showV2
             ? { width: `${width}%`, transition: `width ${duration}s` }
             : {}
         }

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
@@ -1,0 +1,10 @@
+import React from "react";
+import "./ProgressBar.scss";
+
+export default function ProgressBar({ status }) {
+  return (
+    <div className="progress">
+      <div className={`progress-bar progress-bar--${status}`}></div>
+    </div>
+  );
+}

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
@@ -1,14 +1,26 @@
 import React from "react";
 import "./ProgressBar.scss";
+import useVariableProgress from "./useVariableProgress";
 
-export default function ProgressBar({ isLoading, isFinishing }) {
+// ProgressBar simulates the current progress.
+export default function ProgressBar({ isLoading, isFinishing, breakpoints }) {
+  const { width, duration } = useVariableProgress(isLoading, breakpoints);
+
+  // Styling
   // Note - would normally use classnames lib, but intentionally leaving that out for the interview
   let status = isLoading ? "loading" : "";
   status = isFinishing ? "finishing" : status;
 
   return (
     <div className="progress">
-      <div className={`progress-bar progress-bar--${status}`}></div>
+      <div
+        style={
+          isLoading
+            ? { width: `${width}%`, transition: `width ${duration}s` }
+            : {}
+        }
+        className={`progress-bar progress-bar--${status}`}
+      ></div>
     </div>
   );
 }

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.js
@@ -1,7 +1,11 @@
 import React from "react";
 import "./ProgressBar.scss";
 
-export default function ProgressBar({ status }) {
+export default function ProgressBar({ isLoading, isFinishing }) {
+  // Note - would normally use classnames lib, but intentionally leaving that out for the interview
+  let status = isLoading ? "loading" : "";
+  status = isFinishing ? "finishing" : status;
+
   return (
     <div className="progress">
       <div className={`progress-bar progress-bar--${status}`}></div>

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.scss
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.scss
@@ -6,12 +6,11 @@
 }
 
 .progress-bar {
-  height: 5px;
+  height: 6px;
   width: 1px;
   opacity: 0;
   border-radius: inherit;
   background: linear-gradient(to right, $sunrise, $red);
-  transition: width 15s;
 }
 
 .progress-bar--loading {

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.scss
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.scss
@@ -16,6 +16,7 @@
 .progress-bar--loading {
   width: 90%;
   opacity: 1;
+  transition: width 15s;
 }
 
 .progress-bar--finishing {

--- a/src/progress_bar_exercise/components/progress_bar/ProgressBar.scss
+++ b/src/progress_bar_exercise/components/progress_bar/ProgressBar.scss
@@ -1,0 +1,26 @@
+@import "../../../shared_styles/colors.scss";
+
+.progress {
+  height: 6px;
+  border-radius: 40px;
+}
+
+.progress-bar {
+  height: 5px;
+  width: 1px;
+  opacity: 0;
+  border-radius: inherit;
+  background: linear-gradient(to right, $sunrise, $red);
+  transition: width 15s;
+}
+
+.progress-bar--loading {
+  width: 90%;
+  opacity: 1;
+}
+
+.progress-bar--finishing {
+  transition: width 1s, opacity 2s 4s;
+  opacity: 0;
+  width: 100%;
+}

--- a/src/progress_bar_exercise/components/progress_bar/helpers.js
+++ b/src/progress_bar_exercise/components/progress_bar/helpers.js
@@ -1,0 +1,31 @@
+const TOTAL_TIME_LENGTH = 15; // 15 seconds is how long the progress bar takes to reach LAST_POINT
+const LAST_POINT = 90; // LAST POINT is the percent the progress will slow to a stop while waiting
+const ONE_SECOND_IN_MILLESCONDS = 1000;
+
+// Useful for determining the time in seconds for the progress bar to take between two percentage points
+export function calcStepDuration(prevPoint, currentPoint) {
+  const distance = currentPoint - prevPoint;
+  const distanceRatio = distance / LAST_POINT;
+  const distanceInTime = TOTAL_TIME_LENGTH * distanceRatio.toFixed(2);
+
+  return distanceInTime;
+}
+
+// Determines the duration in seconds between all progress bar percentage breakpoints
+export function getBreakPointDurations(breakpoints = [90]) {
+  return breakpoints.map((bp, i) => {
+    let previousBP = breakpoints[i - 1] ?? 0;
+    return calcStepDuration(previousBP, bp);
+  });
+}
+
+// Determines the delay period for subsequent timeouts, since progress bar fires off multiple setTimeouts
+export function getDurationDelays(durations) {
+  let totalDelay = 0;
+
+  return durations.map((duration) => {
+    let delay = totalDelay;
+    totalDelay += duration;
+    return delay * ONE_SECOND_IN_MILLESCONDS;
+  });
+}

--- a/src/progress_bar_exercise/components/progress_bar/helpers.test.js
+++ b/src/progress_bar_exercise/components/progress_bar/helpers.test.js
@@ -2,7 +2,7 @@ import {
   calcStepDuration,
   getBreakPointDurations,
   getDurationDelays,
-} from "./useVariableProgress";
+} from "./helpers";
 
 describe("useProgressBar helpers", () => {
   test("calcStepDuration returns correct length of time between 20% of 15", () => {

--- a/src/progress_bar_exercise/components/progress_bar/useVariableProgress.js
+++ b/src/progress_bar_exercise/components/progress_bar/useVariableProgress.js
@@ -1,39 +1,10 @@
 import { useState, useEffect } from "react";
+import { getBreakPointDurations, getDurationDelays } from "./helpers";
 
-// NOTE - Ideally some of these constants and helpers would be in their own file
-const TOTAL_TIME_LENGTH = 15;
-const LAST_POINT = 90;
-const ONE_SECOND_IN_MILLESCONDS = 1000;
-
-// Calculate the duration of a step based on the distance between
-// two points
-export const calcStepDuration = (prevPoint, currentPoint) => {
-  const distance = currentPoint - prevPoint;
-  const distanceRatio = distance / LAST_POINT;
-  const distanceInTime = TOTAL_TIME_LENGTH * distanceRatio.toFixed(2);
-
-  return distanceInTime;
-};
-
-export const getBreakPointDurations = (breakpoints = [90]) =>
-  breakpoints.map((bp, i) => {
-    let previousBP = breakpoints[i - 1] ?? 0;
-    return calcStepDuration(previousBP, bp);
-  });
-
-export function getDurationDelays(durations) {
-  let totalDelay = 0;
-
-  return durations.map((duration) => {
-    let delay = totalDelay;
-    totalDelay += duration;
-    return delay * ONE_SECOND_IN_MILLESCONDS;
-  });
-}
-
-/** useVariableProgress allows you to declare an array of
- * breakpoints (intended as percentages like 20 or 40) that the
- * progress bar will slow down as as it encounters them.
+/**
+ * useVariableProgress allows you to declare an array of
+ * breakpoints (intended as percentages like 20 or 40) for the
+ * progress bar to slow down as it encounters them.
  */
 export default function useVariableProgress(isLoading, breakpoints) {
   const [width, setWidth] = useState(0);

--- a/src/progress_bar_exercise/components/progress_bar/useVariableProgress.js
+++ b/src/progress_bar_exercise/components/progress_bar/useVariableProgress.js
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+
+// NOTE - Ideally some of these constants and helpers would be in their own file
+const TOTAL_TIME_LENGTH = 15;
+const LAST_POINT = 90;
+const ONE_SECOND_IN_MILLESCONDS = 1000;
+
+// Calculate the duration of a step based on the distance between
+// two points
+export const calcStepDuration = (prevPoint, currentPoint) => {
+  const distance = currentPoint - prevPoint;
+  const distanceRatio = distance / LAST_POINT;
+  const distanceInTime = TOTAL_TIME_LENGTH * distanceRatio.toFixed(2);
+
+  return distanceInTime;
+};
+
+export const getBreakPointDurations = (breakpoints = [90]) =>
+  breakpoints.map((bp, i) => {
+    let previousBP = breakpoints[i - 1] ?? 0;
+    return calcStepDuration(previousBP, bp);
+  });
+
+export function getDurationDelays(durations) {
+  let totalDelay = 0;
+
+  durations.map((duration) => {
+    let delay = totalDelay;
+    totalDelay += duration;
+    return delay * ONE_SECOND_IN_MILLESCONDS;
+  });
+}
+
+/** useVariableProgress allows you to declare an array of
+ * breakpoints (intended as percentages like 20 or 40) that the
+ * progress bar will slow down as as it encounters them.
+ */
+export default function useVariableProgress(isLoading, breakpoints) {
+  const [width, setWidth] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  useEffect(() => {
+    if (isLoading) {
+      let durations = getBreakPointDurations(breakpoints ?? [90]);
+      let delays = getDurationDelays(durations);
+
+      for (let i = 0; i < breakpoints.length; i++) {
+        setTimeout(() => {
+          setWidth(breakpoints[i]);
+          setDuration(durations[i]);
+        }, delays[i]);
+      }
+    }
+  }, [isLoading, breakpoints]);
+
+  return { width, duration };
+}

--- a/src/progress_bar_exercise/components/progress_bar/useVariableProgress.js
+++ b/src/progress_bar_exercise/components/progress_bar/useVariableProgress.js
@@ -24,7 +24,7 @@ export const getBreakPointDurations = (breakpoints = [90]) =>
 export function getDurationDelays(durations) {
   let totalDelay = 0;
 
-  durations.map((duration) => {
+  return durations.map((duration) => {
     let delay = totalDelay;
     totalDelay += duration;
     return delay * ONE_SECOND_IN_MILLESCONDS;
@@ -41,7 +41,7 @@ export default function useVariableProgress(isLoading, breakpoints) {
 
   useEffect(() => {
     if (isLoading) {
-      let durations = getBreakPointDurations(breakpoints ?? [90]);
+      let durations = getBreakPointDurations(breakpoints);
       let delays = getDurationDelays(durations);
 
       for (let i = 0; i < breakpoints.length; i++) {

--- a/src/progress_bar_exercise/components/progress_bar/useVariableProgress.test.js
+++ b/src/progress_bar_exercise/components/progress_bar/useVariableProgress.test.js
@@ -1,0 +1,20 @@
+import {
+  calcStepDuration,
+  getBreakPointDurations,
+} from "./useVariableProgress";
+
+describe("useProgressBar helpers", () => {
+  test("calcStepDuration returns correct length of time between 20% of 15", () => {
+    expect(calcStepDuration(0, 20)).toEqual(3.3);
+  });
+
+  test("getBreakPointDurations is empty", () => {
+    expect(getBreakPointDurations()).toEqual([15]);
+  });
+
+  test("getBreakPointDurations is array of items", () => {
+    expect(getBreakPointDurations([10, 20, 40, 90])).toEqual([
+      1.65, 1.65, 3.3, 8.4,
+    ]);
+  });
+});

--- a/src/progress_bar_exercise/components/progress_bar/useVariableProgress.test.js
+++ b/src/progress_bar_exercise/components/progress_bar/useVariableProgress.test.js
@@ -1,6 +1,7 @@
 import {
   calcStepDuration,
   getBreakPointDurations,
+  getDurationDelays,
 } from "./useVariableProgress";
 
 describe("useProgressBar helpers", () => {
@@ -15,6 +16,12 @@ describe("useProgressBar helpers", () => {
   test("getBreakPointDurations is array of items", () => {
     expect(getBreakPointDurations([10, 20, 40, 90])).toEqual([
       1.65, 1.65, 3.3, 8.4,
+    ]);
+  });
+
+  test("getDurationDelays ", () => {
+    expect(getDurationDelays([1.65, 1.65, 3.3, 8.4])).toEqual([
+      0, 1650, 3300, 6600,
     ]);
   });
 });

--- a/src/progress_bar_exercise/hooks/useSimulateNetworkRequest.js
+++ b/src/progress_bar_exercise/hooks/useSimulateNetworkRequest.js
@@ -1,15 +1,19 @@
 import { useState } from "react";
 
+const STATUS = {
+  IDLE: "IDLE",
+  LOADING: "LOADING",
+  FINISHING: "FINISHING",
+};
+
 export default function useSimulateRequest() {
-  const [status, setStatus] = useState("idle");
+  const [status, setStatus] = useState(STATUS.IDLE);
 
-  function startRequest() {
-    setStatus("loading");
-  }
+  const startRequest = () => setStatus(STATUS.LOADING);
+  const finishRequest = () => setStatus(STATUS.FINISHING);
 
-  function finishRequest() {
-    setStatus("finishing");
-  }
+  const isLoading = status === STATUS.LOADING;
+  const isFinishing = status === STATUS.FINISHING;
 
-  return { status, startRequest, finishRequest };
+  return { isLoading, isFinishing, startRequest, finishRequest };
 }

--- a/src/progress_bar_exercise/hooks/useSimulateNetworkRequest.js
+++ b/src/progress_bar_exercise/hooks/useSimulateNetworkRequest.js
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export default function useSimulateRequest() {
+  const [status, setStatus] = useState("idle");
+
+  function startRequest() {
+    setStatus("loading");
+  }
+
+  function finishRequest() {
+    setStatus("finishing");
+  }
+
+  return { status, startRequest, finishRequest };
+}


### PR DESCRIPTION
### Overview

[Link to design spec](https://github.com/SpiffInc/spiff_react_exercises/issues/1)
[Link to video recording](https://www.dropbox.com/s/jmnf7m6w3g9r7nj/Progress-Bar-V2.mov?dl=0)
^ Note - video does not include the updated toggle button, but behavior of the toggle bar is the same

Progress Bar V2 is similar to V1, except it can be programmed to slow down at specific breakpoints. 

### Approach
V2 required a special approach to handle the breakpoints effectively (although this might have been simple to do with transitions with react 18; I'll have to experiment!). To determine how much to animate the progress bar, we divide the bar into it's steps with the hard-coded total time, and queue subsequent timeouts with delays. 

### Acceptance Criteria
- [x] all appropriate V1 acceptance criteria
- [x] update the progress bar to accept an array of breakpoints that affect the animation of the progress bar. Progress should animate slower around breakpoints than between them. Each breakpoint will be provided as a number that represents a percentage. As in v1, the bar should hang at 90% if the finish button is never clicked

- [x] allow the user to toggle between a progress bar with breakpoints and one without

## Test Cases
[x] toggle bar displays nothing when empty 
[x] toggle bar displays loading at each breakpoint
[ ] toggle bar displays loading correctly with bad breakpoints -- not handled
[x] toggle bar correctly takes 1 second to reach 100% when stalled at 90% 
[x] toggle bar correctly takes 1 second to reach 100% while actively loading

### Known callouts/concerns
- currently the progress bar fades away when completed, but it isn't removed from the DOM or reset. This behavior wasn't explicitly called out, but I believe it'd be worth baking this in. 
- There's currently no good way to 'reset' the progress bar or load a new one. This could be solved by the same work as the above note, but could also be solved with a 'reset' state. 
- some minor improvements could be made by using the classnames lib / tailwind / css in js

- Running multiple progress bars at the same can cause conflicts! They both start and load correctly, but if one progress bar receives the finish state, it can reset the loading state of the other. This would most likely be a blocker, if we planned on running multiple progress bars at the same time. 
- The buttons currently jitter a bit horizontally on click due to the border. I believe we could fix that by leveraging a box shadow instead. 
